### PR TITLE
Part switching

### DIFF
--- a/SimpleAdjustableFairings/FairingSlice.cs
+++ b/SimpleAdjustableFairings/FairingSlice.cs
@@ -157,6 +157,7 @@ namespace SimpleAdjustableFairings
             {
                 for (int i = NumSegments - 1; i >= newNumSegments; i--)
                 {
+                    wallObjects[i].transform.parent = null;
                     UnityEngine.Object.Destroy(wallObjects[i]);
                     wallObjects.RemoveAt(i);
                 }

--- a/SimpleAdjustableFairings/ModelData.cs
+++ b/SimpleAdjustableFairings/ModelData.cs
@@ -35,8 +35,13 @@ namespace SimpleAdjustableFairings
         [Persistent]
         public Vector3 rootOffset;
 
+        [Persistent]
+        public bool enabled = true;
+
         public ResolvedModelData Resolve(GameObject lookupRoot)
         {
+            if (!enabled) return null;
+
             if (lookupRoot == null) throw new ArgumentNullException(nameof(lookupRoot));
 
             if (string.IsNullOrEmpty(transformName)) throw new TransformNameMissingException();

--- a/SimpleAdjustableFairings/ModuleSimpleAdjustableFairing.cs
+++ b/SimpleAdjustableFairings/ModuleSimpleAdjustableFairing.cs
@@ -452,7 +452,11 @@ namespace SimpleAdjustableFairings
             // If we are duplicating in the editor, there will be some leftovers
             // Easier to just get rid of them rather than try to rebuild the hierarchy
             GameObject oldFairing = part.FindModelTransform(FAIRING_ROOT_TRANSFORM_NAME)?.gameObject;
-            if (oldFairing != null) Destroy(oldFairing);
+            if (oldFairing != null)
+            {
+                oldFairing.transform.parent = null;
+                Destroy(oldFairing);
+            }
 
             fairingRoot = new GameObject(FAIRING_ROOT_TRANSFORM_NAME);
             fairingRoot.transform.NestToParent(modelRoot.transform);

--- a/SimpleAdjustableFairings/ModuleSimpleAdjustableFairing.cs
+++ b/SimpleAdjustableFairings/ModuleSimpleAdjustableFairing.cs
@@ -128,6 +128,19 @@ namespace SimpleAdjustableFairings
             if (deployOnStage) Deploy();
         }
 
+        [KSPEvent]
+        public void ModuleDataChanged()
+        {
+            // Not yet initialized
+            if (fairingRoot == null) return;
+
+            FindTransforms();
+            SetupFairing();
+            RenderProceduralDragCubes();
+            UpdateFAR();
+            IgnoreColliders();
+        }
+
         #endregion
 
         #region Actions

--- a/SimpleAdjustableFairings/ModuleSimpleAdjustableFairing.cs
+++ b/SimpleAdjustableFairings/ModuleSimpleAdjustableFairing.cs
@@ -259,6 +259,7 @@ namespace SimpleAdjustableFairings
         private void OnSegmentNumberChange(BaseField field, object oldValue)
         {
             UpdateSegments();
+            NotifyModelUpdate();
             UpdateCargoBay();
             part.ModifyCoM();
             part.RefreshHighlighter();
@@ -483,6 +484,7 @@ namespace SimpleAdjustableFairings
 
             UpdateSegments();
             UpdateTransparency();
+            NotifyModelUpdate();
             UpdateOpen();
             UpdateCargoBay();
             part.ModifyCoM();
@@ -669,6 +671,8 @@ namespace SimpleAdjustableFairings
 
             if (deployAltitude * 1000f < vessel.altitude) Deploy();
         }
+
+        private void NotifyModelUpdate() => part.SendEvent("OnPartModelChanged");
 
         #endregion
     }

--- a/SimpleAdjustableFairings/ModuleSimpleAdjustableFairing.cs
+++ b/SimpleAdjustableFairings/ModuleSimpleAdjustableFairing.cs
@@ -208,8 +208,6 @@ namespace SimpleAdjustableFairings
         {
             base.OnStartFinished(state);
 
-            if (state == StartState.Editor) return;
-
             RenderProceduralDragCubes();
             UpdateFAR();
             IgnoreColliders();
@@ -516,6 +514,8 @@ namespace SimpleAdjustableFairings
 
         private void IgnoreColliders()
         {
+            if (!HighLogic.LoadedSceneIsFlight) return;
+
             CollisionManager.IgnoreCollidersOnVessel(vessel, fairingRoot.GetComponentsInChildren<Collider>());
         }
 

--- a/SimpleAdjustableFairings/ModuleSimpleAdjustableFairing.cs
+++ b/SimpleAdjustableFairings/ModuleSimpleAdjustableFairing.cs
@@ -395,6 +395,11 @@ namespace SimpleAdjustableFairings
                 this.LogError("coneData is null, cannot find transform!");
                 result = false;
             }
+            else if (coneData.enabled == false)
+            {
+                this.LogError("coneData has enabled = false, this is illegal!");
+                result = false;
+            }
             else
             {
                 try

--- a/SimpleAdjustableFairings/ModuleSimpleAdjustableFairing.cs
+++ b/SimpleAdjustableFairings/ModuleSimpleAdjustableFairing.cs
@@ -468,7 +468,7 @@ namespace SimpleAdjustableFairings
 
         private void SetupFairing()
         {
-            // If we are duplicating in the editor, there will be some leftovers
+            // If we are duplicating in the editor or reinitializing, there will be some leftovers
             // Easier to just get rid of them rather than try to rebuild the hierarchy
             GameObject oldFairing = part.FindModelTransform(FAIRING_ROOT_TRANSFORM_NAME)?.gameObject;
             if (oldFairing != null)

--- a/SimpleAdjustableFairings/ModuleSimpleAdjustableFairing.cs
+++ b/SimpleAdjustableFairings/ModuleSimpleAdjustableFairing.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
@@ -105,6 +106,9 @@ namespace SimpleAdjustableFairings
         [SerializeField]
         private string serializedData;
 
+        private bool needsRecalculateDragCubes;
+        private bool needsNotifyFARToRevoxelize;
+
         #endregion
 
         #region Properties
@@ -129,17 +133,33 @@ namespace SimpleAdjustableFairings
         }
 
         [KSPEvent]
-        public void ModuleDataChanged()
+        public void ModuleDataChanged(BaseEventDetails details)
         {
             // Not yet initialized
             if (fairingRoot == null) return;
 
             FindTransforms();
             SetupFairing();
-            RenderProceduralDragCubes();
-            UpdateFAR();
+
+            if (details?.Get<Action>("requestNotifyFARToRevoxelize") is Action requestNotifyFarToRevoxelize)
+                requestNotifyFarToRevoxelize();
+            else
+                NotifyFARToRevoxelize();
+
+
+            if (details?.Get<Action>("requestRecalculateDragCubes") is Action requestRecalculateDragCubes)
+                requestRecalculateDragCubes();
+            else
+                RecalculateDragCubes();
+
             IgnoreColliders();
         }
+
+        [KSPEvent]
+        public void DragCubesWereRecalculated() => needsRecalculateDragCubes = false;
+
+        [KSPEvent]
+        public void FarWasNotifiedToRevoxelize() => needsNotifyFARToRevoxelize = false;
 
         #endregion
 
@@ -221,8 +241,8 @@ namespace SimpleAdjustableFairings
         {
             base.OnStartFinished(state);
 
-            RenderProceduralDragCubes();
-            UpdateFAR();
+            NotifyFARToRevoxelize();
+            RecalculateDragCubes();
             IgnoreColliders();
         }
 
@@ -266,7 +286,8 @@ namespace SimpleAdjustableFairings
         {
             part.OnEditorAttach -= SetupFairingOnAttach;
             SetupFairing();
-            UpdateFAR();
+            NotifyFARToRevoxelize();
+            RecalculateDragCubes();
         }
 
         private void OnSegmentNumberChange(BaseField field, object oldValue)
@@ -276,7 +297,8 @@ namespace SimpleAdjustableFairings
             UpdateCargoBay();
             part.ModifyCoM();
             part.RefreshHighlighter();
-            UpdateFAR();
+            NotifyFARToRevoxelize();
+            RecalculateDragCubes();
         }
 
         private void OnToggleTransparent(BaseField field, object oldValue)
@@ -546,6 +568,8 @@ namespace SimpleAdjustableFairings
         private void UpdateSegments()
         {
             slices.ForEach(slice => slice.NumSegments = (int)numSegments);
+            needsNotifyFARToRevoxelize = true;
+            needsRecalculateDragCubes = true;
         }
 
         private void UpdateTransparency()
@@ -585,17 +609,32 @@ namespace SimpleAdjustableFairings
 #endif
         }
 
-        private void RenderProceduralDragCubes()
+        private void NotifyFARToRevoxelize()
         {
-            DragCube newCube = DragCubeSystem.Instance.RenderProceduralDragCube(part);
-            part.DragCubes.ClearCubes();
-            part.DragCubes.Cubes.Add(newCube);
-            part.DragCubes.ResetCubeWeights();
+            if (!needsNotifyFARToRevoxelize) return;
+
+            part.SendMessage("GeometryPartModuleRebuildMeshData");
+            part.SendMessage(nameof(FarWasNotifiedToRevoxelize));
+            needsNotifyFARToRevoxelize = false;
         }
 
-        private void UpdateFAR()
+        private void RecalculateDragCubes()
         {
-            part.SendMessage("GeometryPartModuleRebuildMeshData");
+            if (!needsRecalculateDragCubes) return;
+
+            IEnumerator RecalculateDragCubesCoroutine()
+            {
+                part.DragCubes.ClearCubes();
+                yield return DragCubeSystem.Instance.SetupDragCubeCoroutine(part, null);
+                part.DragCubes.ForceUpdate(weights: true, occlusion: true);
+                part.DragCubes.SetDragWeights();
+                part.DragCubes.SetPartOcclusion();
+            }
+
+            StartCoroutine(RecalculateDragCubesCoroutine());
+
+            part.SendMessage(nameof(DragCubesWereRecalculated));
+            needsRecalculateDragCubes = false;
         }
 
         private float CalculateFairingMass()
@@ -645,8 +684,11 @@ namespace SimpleAdjustableFairings
             slices.Clear();
 
             part.ModifyCoM();
-            RenderProceduralDragCubes();
-            UpdateFAR();
+
+            needsNotifyFARToRevoxelize = true;
+            NotifyFARToRevoxelize();
+            needsRecalculateDragCubes = true;
+            RecalculateDragCubes();
 
             OnStop.Fire(1f);
 


### PR DESCRIPTION
* Add `enabled` attribute to model data (default `true`)
  * Used for part switching to disable a particular piece of the fairing (since eliminating the node wouldn't do anything)
* Send `OnPartModelChanged` event so other modules can respond to changes in the model
* Listen for `ModuleDataChanged` to rebuild fairing
  * Use `requestNotifyFARToRevoxelize` and `requestRecalculateDragCubes` attributes of event details if present rather than recalculating aero properties ourself, that ensures it's only done once per cycle
* Use better method of recalculating drag cubes
* Send/listen for `DragCubesWereRecalculated` and `FarWasNotifiedToRevoxelize` to make sure actions are only done once per cycle