### PR TITLE
Assign part action window groups

### DIFF
--- a/SimpleAdjustableFairings/ModuleSimpleAdjustableFairing.cs
+++ b/SimpleAdjustableFairings/ModuleSimpleAdjustableFairing.cs
@@ -54,6 +54,12 @@ namespace SimpleAdjustableFairings
         [KSPField]
         public float scale = 1f;
 
+        [KSPField]
+        public string uiGroupName = "fairing";
+
+        [KSPField]
+        public string uiGroupDisplayName = "Fairing";
+
         [Persistent(name = "WALL_BASE")]
         public ModelData wallBaseData = null;
 
@@ -229,6 +235,8 @@ namespace SimpleAdjustableFairings
 
                 CalculateAutodeployAltitude();
             }
+
+            SetUiGroups();
             UpdateDeployAltitudeVisibility();
 
             if (state == StartState.Editor)
@@ -568,6 +576,21 @@ namespace SimpleAdjustableFairings
             this.GetUIControl(nameof(transparentEditor)).onFieldChanged = OnToggleTransparent;
             this.GetUIControl(nameof(openFairing)).onFieldChanged = OnToggleOpen;
             this.GetUIControl(nameof(autoDeploy)).onFieldChanged = OnToggleAutodeploy;
+        }
+
+        private void SetUiGroups()
+        {
+            foreach (BaseField field in Fields)
+            {
+                field.group.name = uiGroupName;
+                field.group.displayName = uiGroupDisplayName;
+            }
+
+            foreach (BaseEvent baseEvent in Events)
+            {
+                baseEvent.group.name = uiGroupName;
+                baseEvent.group.displayName = uiGroupDisplayName;
+            }
         }
 
         private void CalculateAutodeployAltitude()

--- a/SimpleAdjustableFairings/ModuleSimpleAdjustableFairing.cs
+++ b/SimpleAdjustableFairings/ModuleSimpleAdjustableFairing.cs
@@ -724,6 +724,8 @@ namespace SimpleAdjustableFairings
 
             OnMoving.Fire(0f, 1f);
 
+            if (UIPartActionController.Instance is UIPartActionController partActionController && partActionController.GetItem(part, false) is UIPartActionWindow window) window.displayDirty = true;
+
             foreach (FairingSlice slice in slices)
             {
                 GameObject gameObject = slice.SliceRootObject;


### PR DESCRIPTION
Group all of `ModuleSimpleAdjustableFairing`'s fields and events
* Adds two new fields:
  * `uiGroupName` - unique identifier for the group, defaults to `fairing`
  * `uiGroupDisplayName` - name of the group to display in the UI, defaults to `Fairing`